### PR TITLE
Set dragonfly s3 datastore protocol to https

### DIFF
--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -5,6 +5,7 @@ app.configure do |c|
   c.allow_fetch_url = true
 end
 app.datastore = Dragonfly::DataStorage::S3DataStore.new({
+  url_scheme: "https",
   bucket_name: ENV['LE_S3_BUCKET'],
   access_key_id: ENV['LE_S3_ACCESS_KEY'],
   secret_access_key: ENV['LE_S3_SECRET_ACCESS_KEY'],


### PR DESCRIPTION
https://trello.com/c/rTLxhzIv/360-reward-images-not-showing-up-in-ie-8
