### PR TITLE
- Only pass in the current_school.id instead of entire school object, th...

### DIFF
--- a/app/controllers/teachers/bulk_students_controller.rb
+++ b/app/controllers/teachers/bulk_students_controller.rb
@@ -25,7 +25,7 @@ module Teachers
 
     def update
       updater_method = params["form_action_hidden_tag"] == "Delete these students" ? :delete! : :call
-      StudentUpdaterWorker.perform_async(current_person.user.email, params["students"], current_person.schools.first, updater_method)
+      StudentUpdaterWorker.perform_async(current_person.user.email, params["students"], current_school.id, updater_method)
       flash[:notice] = "Bulk process is running."
       redirect_to action: :show
     end

--- a/app/models/batch_student_updater.rb
+++ b/app/models/batch_student_updater.rb
@@ -1,10 +1,10 @@
 # This class is used to updater students in the system in bulk.
 class BatchStudentUpdater
-  attr_reader :students, :school
+  attr_reader :students, :school_id
 
-  def initialize student_params, school, student_class=Student
+  def initialize student_params, school_id, student_class=Student
     @students       = []
-    @school         = school
+    @school_id      = school_id
     @student_params = student_params.dup
     @student_class  = student_class
   end
@@ -19,17 +19,22 @@ class BatchStudentUpdater
         student = @student_class.find(student_param.delete("id"))
         user_param = student_param["user"]
         if classroom_id
-          psl = PersonSchoolLink.find_or_create_by_person_id_and_school_id(student.id, @school["school"]["id"])
+          psl = PersonSchoolLink.find_or_create_by_person_id_and_school_id(student.id, @school_id)
           pscl = PersonSchoolClassroomLink.find_or_create_by_classroom_id_and_person_school_link_id(classroom_id, psl.id)
           pscl.activate
         end
-        responses << student.update_attributes(first_name: student_param["first_name"],
-                                              last_name: student_param["last_name"],
-                                              gender: student_param["gender"],
-                                              grade: student_param["grade"])
-        responses << student.user.update_attributes(username: user_param["username"],
-                                                    password: user_param["password"],
-                                                    password_confirmation: user_param["password"])
+        responses << student.update_attributes(
+          first_name: student_param["first_name"],
+          last_name: student_param["last_name"],
+          gender: student_param["gender"],
+          grade: student_param["grade"]
+        )
+        user_attributes = {
+          username: user_param["username"],
+          password: user_param["password"],
+          password_confirmation: user_param["password"]
+        }.delete_if{ |k, v| v.blank? }
+        responses << student.user.update_attributes(user_attributes)
         students << student
       end
       unless responses.select{|r| r == false}.empty?
@@ -45,7 +50,7 @@ class BatchStudentUpdater
       responses = []
       @student_params.each do |student_param|
         student = @student_class.find(student_param.delete("id"))
-        psl = PersonSchoolLink.find_or_create_by_person_id_and_school_id(student.id, @school["school"]["id"])
+        psl = PersonSchoolLink.find_or_create_by_person_id_and_school_id(student.id, @school_id)
         psl.deactivate!
       end
     end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -71,6 +71,6 @@ Spree::User.class_eval do
    end
 
    def password_required?
-     api_user? ? false : true
+     api_user? ? false : super
    end
 end

--- a/app/workers/student_updater_worker.rb
+++ b/app/workers/student_updater_worker.rb
@@ -1,11 +1,11 @@
 class StudentUpdaterWorker
   include Sidekiq::Worker
 
-  def perform(teacher, students, school, action)
+  def perform(teacher, students, school_id, action)
     if action == 'delete!'
-      BatchStudentUpdater.new(students, school).delete!
+      BatchStudentUpdater.new(students, school_id).delete!
     else
-      batch_student_updater = Proc.new{BatchStudentUpdater.new(students, school).call}
+      batch_student_updater = Proc.new{BatchStudentUpdater.new(students, school_id).call}
       WorkerNotifier.new(teacher, action, &batch_student_updater).call
     end
   end


### PR DESCRIPTION
...at isn't needed.
- Only pass in the password if the password is being updated, otherwise, the Spree::User can't
  saved.
- Fix issue with password_required? being overridden in the user_decorator, which caused password
  to always be required on user updates, unless the user was an api_user.
