### PR TITLE
Trying to setup the session through warden wasn't

### DIFF
--- a/app/controllers/sti_controller.rb
+++ b/app/controllers/sti_controller.rb
@@ -83,9 +83,7 @@ class StiController < ApplicationController
     teacher = Teacher.where(district_guid: params[:districtGUID], sti_id: @client_response["StaffId"]).first
     return false if teacher.nil?
     school = teacher.schools.where(district_guid: params[:districtGUID]).first
-    session["warden.user.user.session"] = {"last_request_at" => Time.now.to_s}
-    session["warden.user.user.key"] = ["Spree::User", [teacher.user.id], nil]
-    session["current_school_id"] = school.id
+    sign_in(teacher.user)
     return true
   end
 


### PR DESCRIPTION
working correctly.

There was no current_user, current_person, or
current_school available.

Opted out of manually setting up session to instead
use the sign_in method provided with devise.

Fixes this exceptional:
https://www.exceptional.io/exceptions/878946755
