### PR TITLE
If the teachers_to_pay method returns 0, there is no need to continue

### DIFF
--- a/app/workers/student_onboard_credit_worker.rb
+++ b/app/workers/student_onboard_credit_worker.rb
@@ -3,12 +3,12 @@ class StudentOnboardCreditWorker
 
   def perform(school_id)
     school = School.find(school_id)
-    puts "School: #{school.name}"
-    credit_manager=CreditManager.new
-    amount_per_teacher = prorated_amount / teachers_to_pay(school).count
+    teachers_to_pay_for_school = teachers_to_pay(school)
+    return false if teachers_to_pay_for_school.blank?
+    credit_manager = CreditManager.new
+    amount_per_teacher = prorated_amount / teachers_to_pay_for_school.count
     amount_per_teacher = [amount_per_teacher, 1].max
-    puts "Amount per Teacher: #{amount_per_teacher}"
-    teachers_to_pay(school).each do |teacher|
+    teachers_to_pay_for_school.each do |teacher|
       credit_manager.monthly_credits_for_onboarded_student_to_teacher school, teacher, amount_per_teacher
     end
   end


### PR DESCRIPTION
trying to process the rest of the worker.

Also, get rid of random puts statements that nobody looks at.

Hopefully, this fixes this exceptional: https://www.exceptional.io/exceptions/679849526

If you don't have access, it's basically a "divide by 0" error that has happened 13,595 times.
