### PR TITLE
When logged in as a School Admin, on the settings page, teachers

### DIFF
--- a/app/controllers/schools/settings_controller.rb
+++ b/app/controllers/schools/settings_controller.rb
@@ -1,6 +1,6 @@
 class Schools::SettingsController < SchoolAdmins::BaseController
   def show
-    @teachers = current_school.teachers.order(:last_name)
+    @teachers = current_school.teachers.order(:first_name, :last_name)
     @distributing_teachers = current_school.distributing_teachers
     @school = current_school
   end


### PR DESCRIPTION
should be ordered by first_name and last_name.

  Fixes https://trello.com/c/wrMf0gYy
