### PR TITLE
Currently the inbox messages count does not coincide

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,8 +1,9 @@
 module MessagesHelper
   def inbox_label_with_message_count string, messages
     output = string
-    if messages.unread.any?
-      output += " [#{messages.unread.count}]"
+    count = messages.from_games.unread.count + messages.from_teacher.unread.count
+    if count > 0
+      output += " [#{count}]"
     end
     output
   end


### PR DESCRIPTION
with the number of messages in the inbox.

This is because we are currently only showing
game and teacher messages. So, we need to only get
a count of those messages.
