### PR TITLE
Scope searched OtuCode by the current_person

### DIFF
--- a/app/controllers/banks_controller.rb
+++ b/app/controllers/banks_controller.rb
@@ -20,18 +20,15 @@ class BanksController < LoggedInController
       redirect_to bank_path and return
     end
 
-    otu_code = OtuCode.find_by_code(params[:code].upcase) if params[:code]
+    otu_code = current_person.otu_codes.where(code: params[:code].upcase) if params[:code]
     if otu_code.present?
       if otu_code.active? && !otu_code.expired?
         @bank = Bank.new
         @bank.claim_bucks(person, otu_code)
         flash[:notice] = 'Credits claimed!'
         person.code_entry_failures.destroy_all
-      elsif otu_code.student.present? && otu_code.student == current_person
+      else
         flash[:error] = 'You already deposited this credit into your account.'
-        person.code_entry_failures.create
-      elsif otu_code.student.present?
-        flash[:error] = 'This credit was deposited by another user already'
         person.code_entry_failures.create
       end
     else


### PR DESCRIPTION
The issue before was that since codes were not
unique, when we searched all OtuCodes for a
specific code, we had a good chance of pulling
back a code that was for a different user.

This method isn't bulletproof. There is still a
possibility for the same user to have multiple
otu_codes that have the same code, but it's highly
unlikely, and the underlying issue has been resolved
by adding a unique constraint on codes. So, this
check is only for the existing data.
