### PR TITLE
Add weekly/monthly automatic credits jobs to cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -39,3 +39,11 @@ end
 every '0 9 1 * *' do
   runner "BuckDistributor.new.run"
 end
+
+every :saturday do
+  rake "le:award_weekly_automatic_credits"
+end
+
+every "0 0 1 * *" do
+  rake "le:award_monthly_automatic_credits"
+end

--- a/lib/tasks/le.rake
+++ b/lib/tasks/le.rake
@@ -67,11 +67,14 @@ namespace :le do
     end
   end
 
+  # Note that this runs the previous month, because it is much easier to setup a cron job to run
+  # at the first of the month, than the end of the month, because months have different numbers
+  # of days and you have to also take into account leap year.
   desc "Award monthly automatic credits"
   task :award_monthly_automatic_credits => :environment do
     School.inow_schools.has_monthly_automatic_credit_amounts.each do |school|
-      start_date = Time.zone.now.beginning_of_month.strftime("%Y-%m-%d")
-      end_date = Time.zone.now.end_of_month.strftime("%Y-%m-%d")
+      start_date = 1.month.ago.beginning_of_month.strftime("%Y-%m-%d")
+      end_date = 1.month.ago.end_of_month.strftime("%Y-%m-%d")
       credit_manager = CreditManager.new
       sti_link_token = StiLinkToken.where(district_guid: school.district_guid).first
       next unless sti_link_token


### PR DESCRIPTION
These jobs were manually entered into the cron and
got overwritten. They should be in the schedule.rb,
so this doesn't happen again.

The monthly job was changed so that it runs at the
beginning of the month and runs the last month,
simply because it is much easier to setup a cron
entry to run on the first of the month, than dealing
with creating a cron job to run on the last day of the
month.
