### PR TITLE
Use the latest school, if student has more than 1

### DIFF
--- a/app/controllers/sti_controller.rb
+++ b/app/controllers/sti_controller.rb
@@ -87,7 +87,11 @@ class StiController < ApplicationController
     student_sti_id = params["studentIds"].split(",").first if params["studentIds"].present?
     if student_sti_id.present?
       student = Student.where(district_guid: params[:districtGUID], sti_id: student_sti_id).first
-      session[:current_school_id] = student.school.id
+      # Use the latest school the student was linked with
+      #  this fixes yet another bug where a student can be
+      #  associated to multiple schools, even though they are
+      #  only suppose to be associated to 1.
+      session[:current_school_id] = student.person_school_links.order('created_at desc').first.school_id
     else
       # This is left in, just so the iFrame doesn't break if there are no studentIds
       session[:current_school_id] = school.id


### PR DESCRIPTION
A student should only be associated to one active
school at a time, but for some reason, iNow will
sometimes have them associated to multiple. So,
in order to hopefully have less issues from the
give_credits hack in place, I've ordered associated
schools by created_at and chosen the latest one added,
which is hopefully the correct one.
