### PR TITLE
Fix for LE-917 and LE-919

### DIFF
--- a/app/views/teachers/messages/admin_message.html.haml
+++ b/app/views/teachers/messages/admin_message.html.haml
@@ -1,7 +1,7 @@
 .main-content-wrapper-no-bg
   .primary-content
     .admin-message-content
-      %h2 Admin Message
+      %h1 Admin Message
       = form_for @message do |f|
         .select-message
           = f.label :subject


### PR DESCRIPTION
LE-917 : Admin - Messages - Message headers are not consistently bold
LE-919 : Admin - Messages - Admin Message is showing a header of h2 instead of h1